### PR TITLE
Copy resources from project source directory to prevent invalid paths…

### DIFF
--- a/pine/CMakeLists.txt
+++ b/pine/CMakeLists.txt
@@ -140,5 +140,5 @@ set_target_properties(
 add_custom_command(
     TARGET pine
     POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/resources/"
+    COMMAND ${CMAKE_COMMAND} -E copy_directory "${PROJECT_SOURCE_DIR}/resources/"
             "${CMAKE_BINARY_DIR}/bin/resources/")


### PR DESCRIPTION
… when pine is as a package.